### PR TITLE
feat(sdk): Python client (chalkboard-sdk v0.1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,31 @@ All generated videos are automatically indexed into a SQLite database (`library.
 
 ---
 
+## Python SDK
+
+If you'd rather call Chalkboard from a script than the CLI, there's a typed sync Python client at [`sdk/python/`](sdk/python). It targets the **hosted** version at <https://chalkboard.studio/api/v1>:
+
+```python
+from chalkboard import ChalkboardClient
+
+client = ChalkboardClient(api_key="chk_live_…")  # create one at /account
+job    = client.create_job(topic="How hash tables work")
+final  = client.wait_for_completion(job.id, timeout=600)
+client.download_file(final.id, "final.mp4", out_path="hash-tables.mp4")
+```
+
+The same client also works against a **self-hosted** Chalkboard — pass `base_url="http://localhost:8000/api/v1"` to the constructor. Self-hosted installs typically don't need an API key (this repo's server has no multi-tenant auth out of the box).
+
+Install:
+
+```bash
+pip install https://github.com/nicglazkov/Chalkboard/releases/download/sdk-py/v0.1.1/chalkboard_sdk-0.1.1-py3-none-any.whl
+```
+
+Full SDK reference + examples: [`sdk/python/README.md`](sdk/python/README.md). Hosted API docs: <https://chalkboard.studio/docs/api>.
+
+---
+
 ## Development
 
 ### Run tests
@@ -441,6 +466,7 @@ docker/
   Dockerfile      # extends manimcommunity/manim:v0.20.1
   render.sh       # renders scene.py inside Docker
 server/         # FastAPI app, job store, routes, library, static frontend
+sdk/python/     # Typed Python client for the hosted (or self-hosted) API
 tests/            # one test file per module
 config.py         # env var loading
 main.py           # CLI entry point

--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[co]
+*.egg-info/
+build/
+dist/

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -7,12 +7,13 @@ want to know exactly what a method does.
 
 ## Install
 
-```bash
-pip install chalkboard-sdk
-```
+The hosted Chalkboard service is in closed beta — the SDK is shipped
+via GitHub Releases on this repo until the v1 surface stabilises and
+we publish to PyPI.
 
-(Closed-beta period: ship via GitHub Releases until the v1 surface
-stabilises. PyPI release lands once the API contract is locked.)
+```bash
+pip install https://github.com/nicglazkov/Chalkboard/releases/download/sdk-py/v0.1.1/chalkboard_sdk-0.1.1-py3-none-any.whl
+```
 
 ## Quickstart
 
@@ -111,7 +112,9 @@ except ChalkboardError as e:
 
 ## Source
 
-The pipeline code is open-source at
-[github.com/nicglazkov/Chalkboard](https://github.com/nicglazkov/Chalkboard).
-This SDK lives in the closed-source operational repo and gets cut to
-GitHub Releases on every API release.
+This SDK and the underlying multi-agent pipeline are both open source
+in [github.com/nicglazkov/Chalkboard](https://github.com/nicglazkov/Chalkboard).
+The pipeline can be self-hosted (clone the repo, set `ANTHROPIC_API_KEY`,
+run `python run_server.py`) and the SDK works against either the hosted
+endpoint at <https://chalkboard.studio> or your own deployment via the
+`base_url=` kwarg.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,117 @@
+# chalkboard-sdk
+
+Python client for the [Chalkboard API](https://chalkboard.studio/docs/api).
+Typed, sync, one-screen-of-code, no codegen. The full handwritten
+client lives in `chalkboard/client.py` — read it end-to-end if you
+want to know exactly what a method does.
+
+## Install
+
+```bash
+pip install chalkboard-sdk
+```
+
+(Closed-beta period: ship via GitHub Releases until the v1 surface
+stabilises. PyPI release lands once the API contract is locked.)
+
+## Quickstart
+
+```python
+from chalkboard import ChalkboardClient
+
+client = ChalkboardClient(api_key="chk_live_…")
+
+# Submit a job. Idempotency-Key is optional but recommended on retries.
+job = client.create_job(
+    topic="How hash tables actually work",
+    effort="medium",
+    theme="chalkboard",
+    idempotency_key=client.fresh_idempotency_key(),
+)
+
+# Block until the pipeline finishes (poll-based).
+final = client.wait_for_completion(job.id, timeout=600)
+print(final.status, final.output_files)
+
+# Or stream events as they arrive.
+for event in client.stream_events(job.id):
+    print(event)
+    if event.get("done"):
+        break
+
+# Download the final mp4.
+client.download_file(final.id, "final.mp4", out_path="hash-tables.mp4")
+```
+
+## Test mode
+
+Pass a `chk_test_…` key (creatable at <https://chalkboard.studio/account>)
+to force the cheapest pipeline settings — `effort=low`, `quality=low`,
+`qa_density=zero`, Haiku model. Roughly 4× cheaper. Useful for CI
+smoke-tests against new features. The same code path runs; just at
+the cheap end of every dial.
+
+## Webhooks
+
+Subscribe to `job.completed` / `job.failed` / `job.cancelled` at
+[/account](https://chalkboard.studio/account) → "Webhooks". On the
+receiver side, verify the signature:
+
+```python
+from chalkboard import verify_webhook_signature
+
+SIGNING_SECRET = os.environ["CHALKBOARD_SIGNING_SECRET"]
+
+# In your FastAPI / Flask / Django handler:
+def receive_webhook(request):
+    body = request.body  # raw bytes — don't json.parse before verifying
+    sig = request.headers["X-Chalkboard-Signature"]
+    if not verify_webhook_signature(SIGNING_SECRET, body, sig):
+        return Response(status_code=401)
+    event = json.loads(body)
+    # ... handle event["data"] (JobResponse-shaped)
+```
+
+`verify_webhook_signature` returns `False` on a tampered body, wrong
+secret, malformed header, or signature older than 5 minutes (replay
+protection). Constant-time compare via `hmac.compare_digest`.
+
+## Errors
+
+Every non-2xx response raises a typed exception. Catch the parent
+`ChalkboardError` if you don't care about the specifics:
+
+```python
+from chalkboard import (
+    ChalkboardError, ChalkboardRateLimitError, ChalkboardSpendCapError,
+)
+
+try:
+    client.create_job(topic="…")
+except ChalkboardRateLimitError as e:
+    time.sleep(e.retry_after_seconds or 5)
+except ChalkboardSpendCapError:
+    # Daily $10 cap reached. Resets in 24h.
+    ...
+except ChalkboardError as e:
+    print(f"{e.status}: {e.detail}")
+```
+
+## What's NOT in this SDK (yet)
+
+- **Async client.** Sync only for now. Add `httpx.AsyncClient` wrappers
+  if you need them.
+- **Generated bindings.** This is a hand-written client. The
+  `/openapi.json` spec is publicly available if you want to feed it
+  into `openapi-python-client` or similar.
+- **Webhook management endpoints from API-key auth.** The server
+  refuses `/webhooks` POST/DELETE under API-key auth as a privilege-
+  escalation guard. Use the `/account` web UI to create webhooks, then
+  use this client to receive them.
+
+## Source
+
+The pipeline code is open-source at
+[github.com/nicglazkov/Chalkboard](https://github.com/nicglazkov/Chalkboard).
+This SDK lives in the closed-source operational repo and gets cut to
+GitHub Releases on every API release.

--- a/sdk/python/chalkboard/__init__.py
+++ b/sdk/python/chalkboard/__init__.py
@@ -1,0 +1,36 @@
+"""Chalkboard Python SDK — typed wrappers around the public REST API.
+
+Quickstart:
+
+    from chalkboard import ChalkboardClient
+
+    client = ChalkboardClient(api_key="chk_live_…")
+    job = client.create_job(topic="How hash tables work")
+    final = client.wait_for_completion(job.id)
+    client.download_file(final.id, "final.mp4", out_path="hash-tables.mp4")
+
+The handwritten client is intentionally small (~one screen of code) so
+users can read it end-to-end. Generated bindings from `/openapi.json`
+are easy to layer on later if anyone wants the full surface — for now,
+this covers the four canonical flows: create / poll / stream / library.
+"""
+from .client import ChalkboardClient, ChalkboardConfig
+from .exceptions import (
+    ChalkboardError, ChalkboardAuthError, ChalkboardRateLimitError,
+    ChalkboardSpendCapError, ChalkboardConflictError, ChalkboardNotFoundError,
+    ChalkboardValidationError, ChalkboardServerError,
+)
+from .models import JobResponse, VideoMeta, ApiKeyMeta, WebhookMeta
+from .webhooks import verify_webhook_signature
+
+__all__ = [
+    "ChalkboardClient", "ChalkboardConfig",
+    "JobResponse", "VideoMeta", "ApiKeyMeta", "WebhookMeta",
+    "ChalkboardError",
+    "ChalkboardAuthError", "ChalkboardRateLimitError", "ChalkboardSpendCapError",
+    "ChalkboardConflictError", "ChalkboardNotFoundError",
+    "ChalkboardValidationError", "ChalkboardServerError",
+    "verify_webhook_signature",
+]
+
+__version__ = "0.1.1"   # mirror the API/app version that this SDK pairs with

--- a/sdk/python/chalkboard/client.py
+++ b/sdk/python/chalkboard/client.py
@@ -1,0 +1,322 @@
+"""Sync client for the Chalkboard public API.
+
+Wraps `httpx.Client` with auth + idempotency + structured-error
+plumbing. Only sync for now — async wrappers are easy to add (httpx
+already supports both surfaces) but aren't shipped in v0.1 to keep
+the SDK small.
+
+Example:
+
+    from chalkboard import ChalkboardClient
+
+    client = ChalkboardClient(api_key="chk_live_…")
+    job = client.create_job(topic="How hash tables work")
+    final = client.wait_for_completion(job.id, timeout=600)
+    client.download_file(final.id, "final.mp4", out_path="hash-tables.mp4")
+"""
+from __future__ import annotations
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+
+import httpx
+
+from .exceptions import ChalkboardError, from_response
+from .models import ApiKeyMeta, JobResponse, VideoMeta, WebhookMeta
+
+
+DEFAULT_BASE_URL = "https://chalkboard.studio/api/v1"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+DEFAULT_POLL_INTERVAL_SECONDS = 5.0
+
+
+@dataclass
+class ChalkboardConfig:
+    """Knobs for the client. Most users only ever touch `api_key`."""
+    api_key: str
+    base_url: str = DEFAULT_BASE_URL
+    timeout: float = DEFAULT_TIMEOUT_SECONDS
+    user_agent: str = f"chalkboard-python/0.1.1"
+
+
+class ChalkboardClient:
+    """Sync HTTP client for the Chalkboard API.
+
+    Creates one underlying `httpx.Client` per instance and reuses the
+    connection pool. Safe to share across threads — `httpx.Client` is
+    thread-safe.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        config: ChalkboardConfig | None = None,
+    ):
+        if config is None:
+            if not api_key:
+                raise ValueError("api_key (or config) is required")
+            config = ChalkboardConfig(
+                api_key=api_key, base_url=base_url, timeout=timeout,
+            )
+        self.config = config
+        self._http = httpx.Client(
+            base_url=config.base_url,
+            timeout=config.timeout,
+            headers={
+                "Authorization": f"Bearer {config.api_key}",
+                "User-Agent": config.user_agent,
+            },
+        )
+
+    # ── Lifecycle ───────────────────────────────────────────────────────────
+    def close(self) -> None:
+        """Release the underlying connection pool. Optional — Python's
+        garbage collector calls __del__ on the http client which closes
+        too. But explicit is friendlier in long-running processes."""
+        self._http.close()
+
+    def __enter__(self) -> "ChalkboardClient":
+        return self
+
+    def __exit__(self, *a) -> None:
+        self.close()
+
+    # ── Internal request helper ─────────────────────────────────────────────
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Any = None,
+        params: dict | None = None,
+        idempotency_key: str | None = None,
+        stream: bool = False,
+    ) -> httpx.Response:
+        headers: dict[str, str] = {}
+        if idempotency_key:
+            headers["Idempotency-Key"] = idempotency_key
+        resp = self._http.request(
+            method, path, json=json, params=params, headers=headers or None,
+        )
+        if resp.status_code >= 400:
+            raise from_response(resp)
+        return resp
+
+    # ── Jobs ────────────────────────────────────────────────────────────────
+    def create_job(
+        self,
+        *,
+        topic: str,
+        effort: str = "medium",
+        audience: str = "intermediate",
+        tone: str = "casual",
+        theme: str = "chalkboard",
+        template: str | None = None,
+        speed: float = 1.0,
+        burn_captions: bool = False,
+        quiz: bool = False,
+        urls: list[str] | None = None,
+        github: list[str] | None = None,
+        qa_density: str = "normal",
+        email_on_complete: bool = True,
+        quality: str = "medium",
+        model: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> JobResponse:
+        """Submit a new job.
+
+        Pass `idempotency_key` if you might retry — a UUID v4 is fine.
+        Reusing the same key with the same body within 24 hours replays
+        the original response (no duplicate paid job); reusing it with
+        a different body raises ChalkboardConflictError.
+        """
+        body: dict[str, Any] = {
+            "topic": topic,
+            "effort": effort, "audience": audience, "tone": tone,
+            "theme": theme, "speed": speed,
+            "burn_captions": burn_captions, "quiz": quiz,
+            "urls": list(urls or []), "github": list(github or []),
+            "qa_density": qa_density,
+            "email_on_complete": email_on_complete,
+            "quality": quality,
+        }
+        if template is not None:
+            body["template"] = template
+        if model is not None:
+            body["model"] = model
+        resp = self._request("POST", "/jobs", json=body, idempotency_key=idempotency_key)
+        return JobResponse.from_dict(resp.json())
+
+    def get_job(self, job_id: str) -> JobResponse:
+        resp = self._request("GET", f"/jobs/{job_id}")
+        return JobResponse.from_dict(resp.json())
+
+    def list_jobs(self) -> list[JobResponse]:
+        resp = self._request("GET", "/jobs")
+        return [JobResponse.from_dict(d) for d in resp.json()]
+
+    def cancel_job(self, job_id: str) -> dict:
+        """Request cancellation. Returns the API's `{"status": "cancelling"}`
+        envelope or `{"status": "<terminal>"}` if the job already finished."""
+        resp = self._request("DELETE", f"/jobs/{job_id}")
+        return resp.json()
+
+    def retry_job(
+        self, job_id: str, *, idempotency_key: str | None = None,
+    ) -> JobResponse:
+        """Re-run a terminal job with the same parameters. Source must
+        be in completed/failed/cancelled. Test-mode follows THIS request's
+        auth, not the source's mode."""
+        resp = self._request(
+            "POST", f"/jobs/{job_id}/retry", idempotency_key=idempotency_key,
+        )
+        return JobResponse.from_dict(resp.json())
+
+    def rerender_job(
+        self, job_id: str, *, idempotency_key: str | None = None,
+    ) -> JobResponse:
+        """Reuse the source's script + voiceover; regenerate the Manim
+        scene only. Cheaper than retry — no script/research/TTS cost."""
+        resp = self._request(
+            "POST", f"/jobs/{job_id}/rerender", idempotency_key=idempotency_key,
+        )
+        return JobResponse.from_dict(resp.json())
+
+    def wait_for_completion(
+        self,
+        job_id: str,
+        *,
+        timeout: float = 600.0,
+        poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+    ) -> JobResponse:
+        """Block until the job reaches a terminal state. Returns the
+        final JobResponse. Raises TimeoutError if the deadline elapses
+        without the job finishing."""
+        deadline = time.monotonic() + timeout
+        while True:
+            job = self.get_job(job_id)
+            if job.status in ("completed", "failed", "cancelled"):
+                return job
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Job {job_id} still {job.status} after {timeout:.0f}s"
+                )
+            time.sleep(poll_interval)
+
+    def stream_events(self, job_id: str) -> Iterator[dict]:
+        """SSE generator yielding pipeline events as they arrive. The
+        final event is `{"done": true}`; the iterator stops there.
+
+        Example:
+            for event in client.stream_events(job.id):
+                print(event)
+        """
+        with self._http.stream(
+            "GET", f"/jobs/{job_id}/events",
+        ) as resp:
+            if resp.status_code >= 400:
+                # `httpx.Response` from a stream needs `.read()` before .json()
+                resp.read()
+                raise from_response(resp)
+            buffer = ""
+            for line in resp.iter_lines():
+                # SSE format: lines beginning with `data: <json>`
+                if not line:
+                    if buffer:
+                        import json as _json
+                        try:
+                            event = _json.loads(buffer)
+                            buffer = ""
+                            yield event
+                            if event.get("done"):
+                                return
+                        except _json.JSONDecodeError:
+                            buffer = ""
+                    continue
+                if line.startswith("data: "):
+                    buffer = line[len("data: "):]
+
+    # ── Files ───────────────────────────────────────────────────────────────
+    def download_file(
+        self, job_id: str, filename: str, *, out_path: str | Path | None = None,
+    ) -> Path:
+        """Download one of the job's output files (final.mp4, thumb.jpg,
+        captions.srt, …). Streams to disk so large files don't materialise
+        in memory."""
+        out = Path(out_path) if out_path else Path(filename)
+        with self._http.stream("GET", f"/jobs/{job_id}/files/{filename}") as resp:
+            if resp.status_code >= 400:
+                resp.read()
+                raise from_response(resp)
+            with out.open("wb") as f:
+                for chunk in resp.iter_bytes():
+                    f.write(chunk)
+        return out
+
+    # ── Library ─────────────────────────────────────────────────────────────
+    def list_videos(
+        self, *, q: str = "", limit: int = 50, offset: int = 0,
+        sort: str = "newest", status: str | None = None,
+    ) -> list[VideoMeta]:
+        params: dict[str, Any] = {"limit": limit, "offset": offset, "sort": sort}
+        if q:
+            params["q"] = q
+        if status:
+            params["status"] = status
+        resp = self._request("GET", "/library", params=params)
+        body = resp.json()
+        # The response envelope is {videos, total, limit, offset}; extract.
+        videos = body.get("videos", body) if isinstance(body, dict) else body
+        return [VideoMeta.from_dict(d) for d in videos]
+
+    def get_video(self, run_id: str) -> VideoMeta:
+        resp = self._request("GET", f"/library/{run_id}")
+        return VideoMeta.from_dict(resp.json())
+
+    def delete_video(self, run_id: str) -> None:
+        self._request("DELETE", f"/library/{run_id}")
+
+    # ── Webhooks ────────────────────────────────────────────────────────────
+    # Webhook management is gated to ID-token / cookie auth on the server
+    # side (PR 4 privilege-escalation guard). API-key callers will get a
+    # 403 on the *_webhook methods below; they're included for completeness
+    # so a script doing one-time setup can use them with a Firebase ID
+    # token, but the typical user creates webhooks via /account.
+
+    def list_webhooks(self) -> list[WebhookMeta]:
+        resp = self._request("GET", "/webhooks")
+        return [WebhookMeta.from_dict(d) for d in resp.json()]
+
+    # ── API keys ────────────────────────────────────────────────────────────
+    # Same caveat — the `/account/api-keys` endpoints refuse API-key
+    # auth. Included so an admin running a setup script with a Firebase
+    # ID token can list keys for audit.
+
+    def list_api_keys(self) -> list[ApiKeyMeta]:
+        # Note: this endpoint is at /api/account/api-keys, NOT
+        # /api/v1/account/.... Use a distinct path because account
+        # management isn't part of the v1 surface.
+        with httpx.Client(
+            base_url=self.config.base_url.rsplit("/v1", 1)[0],
+            timeout=self.config.timeout,
+            headers={
+                "Authorization": f"Bearer {self.config.api_key}",
+                "User-Agent": self.config.user_agent,
+            },
+        ) as alt:
+            resp = alt.get("/account/api-keys")
+            if resp.status_code >= 400:
+                raise from_response(resp)
+            return [ApiKeyMeta.from_dict(d) for d in resp.json()]
+
+    # ── Convenience: idempotency key generator ──────────────────────────────
+    @staticmethod
+    def fresh_idempotency_key() -> str:
+        """UUID v4 — sufficient entropy for the 24h key window. Convenience
+        for callers who don't want to import `uuid` themselves."""
+        return str(uuid.uuid4())

--- a/sdk/python/chalkboard/exceptions.py
+++ b/sdk/python/chalkboard/exceptions.py
@@ -1,0 +1,100 @@
+"""Exception hierarchy for the Chalkboard SDK.
+
+Every error is a subclass of `ChalkboardError`. Subclasses are picked
+based on the HTTP status the API returned so callers can `except` on
+specific failure modes (auth, rate limits, validation) without parsing
+the `detail` string. The full response is preserved on `.response` for
+deeper inspection.
+"""
+from __future__ import annotations
+from typing import Any
+
+
+class ChalkboardError(Exception):
+    """Base class for every SDK error. Always carries the HTTP status,
+    the parsed `detail` (or raw text on non-JSON responses), and the
+    raw `httpx.Response` for the rare case a caller needs the headers."""
+
+    def __init__(self, message: str, *, status: int | None = None,
+                 detail: Any = None, response=None):
+        super().__init__(message)
+        self.status = status
+        self.detail = detail
+        self.response = response
+
+
+class ChalkboardAuthError(ChalkboardError):
+    """401 / 403 — invalid or revoked API key, banned account, or trying
+    to manage keys/webhooks via API-key auth (use the web UI)."""
+
+
+class ChalkboardRateLimitError(ChalkboardError):
+    """429 — rate limit exceeded. The `retry_after_seconds` attribute is
+    parsed from the `Retry-After` response header."""
+
+    def __init__(self, *args, retry_after_seconds: float | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.retry_after_seconds = retry_after_seconds
+
+
+class ChalkboardSpendCapError(ChalkboardError):
+    """402 — daily spend cap reached. Resets in 24h. Email
+    hello@chalkboard.studio if you need a higher cap."""
+
+
+class ChalkboardConflictError(ChalkboardError):
+    """409 — Idempotency-Key reused with a different request body, or
+    retrying an in-flight job. Generate a new key for distinct requests."""
+
+
+class ChalkboardNotFoundError(ChalkboardError):
+    """404 — job / video / webhook doesn't exist or doesn't belong to
+    the authenticated account. Deliberately ambiguous."""
+
+
+class ChalkboardValidationError(ChalkboardError):
+    """422 — request body failed validation. `detail` is the FastAPI
+    error array (list of {`loc`, `msg`, `type`} dicts)."""
+
+
+class ChalkboardServerError(ChalkboardError):
+    """5xx — server-side problem. Safe to retry (with the same
+    Idempotency-Key if present) — 5xx responses are not cached by the
+    API's idempotency layer."""
+
+
+def from_response(resp) -> ChalkboardError:
+    """Translate an `httpx.Response` (status >= 400) into the right
+    SDK exception subclass. Used by `client.py` on every non-2xx."""
+    status = resp.status_code
+    try:
+        body = resp.json()
+        detail = body.get("detail", body) if isinstance(body, dict) else body
+    except Exception:
+        detail = resp.text
+
+    msg = f"HTTP {status}: {detail!s}"
+
+    if status in (401, 403):
+        return ChalkboardAuthError(msg, status=status, detail=detail, response=resp)
+    if status == 402:
+        return ChalkboardSpendCapError(msg, status=status, detail=detail, response=resp)
+    if status == 404:
+        return ChalkboardNotFoundError(msg, status=status, detail=detail, response=resp)
+    if status == 409:
+        return ChalkboardConflictError(msg, status=status, detail=detail, response=resp)
+    if status == 422:
+        return ChalkboardValidationError(msg, status=status, detail=detail, response=resp)
+    if status == 429:
+        retry_after = resp.headers.get("Retry-After")
+        try:
+            retry_seconds = float(retry_after) if retry_after else None
+        except ValueError:
+            retry_seconds = None
+        return ChalkboardRateLimitError(
+            msg, status=status, detail=detail, response=resp,
+            retry_after_seconds=retry_seconds,
+        )
+    if 500 <= status < 600:
+        return ChalkboardServerError(msg, status=status, detail=detail, response=resp)
+    return ChalkboardError(msg, status=status, detail=detail, response=resp)

--- a/sdk/python/chalkboard/models.py
+++ b/sdk/python/chalkboard/models.py
@@ -1,0 +1,134 @@
+"""Typed response models. Pydantic-free — plain dataclasses with a
+`from_dict` classmethod so the SDK's only runtime dependency is httpx.
+
+The shape mirrors `server/models.py`. We don't share the module
+between the server and the SDK because the server's dataclasses
+import config / asyncpg / firebase — too much surface for an end-user
+package."""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+@dataclass
+class JobResponse:
+    id: str
+    status: Literal["pending", "running", "completed", "failed", "cancelled"]
+    topic: str
+    events: list[dict] = field(default_factory=list)
+    error: str | None = None
+    output_files: list[str] = field(default_factory=list)
+    created_at: str | None = None
+    mode: Literal["live", "test"] = "live"
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "JobResponse":
+        return cls(
+            id=d["id"], status=d["status"], topic=d["topic"],
+            events=list(d.get("events") or []),
+            error=d.get("error"),
+            output_files=list(d.get("output_files") or []),
+            created_at=d.get("created_at"),
+            mode=d.get("mode", "live"),
+        )
+
+
+@dataclass
+class VideoMeta:
+    run_id: str
+    user_id: str = ""
+    topic: str = ""
+    title: str = ""
+    created_at: str = ""
+    duration_sec: float = 0.0
+    quality: str = "medium"
+    thumb_path: str | None = None
+    script: str = ""
+    effort: str = "medium"
+    audience: str = "intermediate"
+    tone: str = "casual"
+    theme: str = "chalkboard"
+    template: str | None = None
+    speed: float = 1.0
+    status: str = "completed"
+    model: str = ""
+    narrator: str = ""
+    test_mode: bool = False
+    output_files: list[str] = field(default_factory=list)
+    urls: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "VideoMeta":
+        return cls(
+            run_id=d["run_id"],
+            user_id=d.get("user_id", ""),
+            topic=d.get("topic", ""),
+            title=d.get("title", ""),
+            created_at=d.get("created_at", ""),
+            duration_sec=float(d.get("duration_sec", 0.0)),
+            quality=d.get("quality", "medium"),
+            thumb_path=d.get("thumb_path"),
+            script=d.get("script", ""),
+            effort=d.get("effort", "medium"),
+            audience=d.get("audience", "intermediate"),
+            tone=d.get("tone", "casual"),
+            theme=d.get("theme", "chalkboard"),
+            template=d.get("template"),
+            speed=float(d.get("speed", 1.0)),
+            status=d.get("status", "completed"),
+            model=d.get("model", ""),
+            narrator=d.get("narrator", ""),
+            test_mode=bool(d.get("test_mode", False)),
+            output_files=list(d.get("output_files") or []),
+            urls=dict(d.get("urls") or {}),
+        )
+
+
+@dataclass
+class ApiKeyMeta:
+    id: str
+    name: str
+    prefix: str
+    hint: str
+    created_at: str
+    last_used_at: str | None
+    revoked_at: str | None
+    expires_at: str | None
+    is_active: bool
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "ApiKeyMeta":
+        return cls(
+            id=d["id"], name=d["name"], prefix=d["prefix"], hint=d["hint"],
+            created_at=d["created_at"],
+            last_used_at=d.get("last_used_at"),
+            revoked_at=d.get("revoked_at"),
+            expires_at=d.get("expires_at"),
+            is_active=bool(d.get("is_active", False)),
+        )
+
+
+@dataclass
+class WebhookMeta:
+    id: str
+    url: str
+    events: list[str]
+    description: str
+    created_at: str
+    disabled_at: str | None
+    consecutive_failures: int
+    last_delivered_at: str | None
+    is_active: bool
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "WebhookMeta":
+        return cls(
+            id=d["id"], url=d["url"],
+            events=list(d.get("events") or []),
+            description=d.get("description", ""),
+            created_at=d["created_at"],
+            disabled_at=d.get("disabled_at"),
+            consecutive_failures=int(d.get("consecutive_failures", 0)),
+            last_delivered_at=d.get("last_delivered_at"),
+            is_active=bool(d.get("is_active", False)),
+        )

--- a/sdk/python/chalkboard/webhooks.py
+++ b/sdk/python/chalkboard/webhooks.py
@@ -1,0 +1,55 @@
+"""Webhook signature verification — re-implements the server's
+`verify_signature` helper as a stdlib-only function so users don't
+have to copy-paste it from the docs.
+
+The server-side code lives in `server/webhooks.py` and is the source
+of truth; if anything changes there, mirror it here.
+"""
+from __future__ import annotations
+import hashlib
+import hmac
+import time
+
+
+def verify_webhook_signature(
+    secret: str,
+    payload_bytes: bytes,
+    signature_header: str,
+    *,
+    tolerance_seconds: int = 300,
+) -> bool:
+    """Verify the `X-Chalkboard-Signature` header against the raw POST
+    body.
+
+    Returns False on malformed header, expired timestamp (replay
+    protection), or HMAC mismatch. Returns True on a fresh + valid
+    signature.
+
+    Example FastAPI receiver:
+
+        from chalkboard import verify_webhook_signature
+
+        @app.post("/chalkboard-webhook")
+        async def receive(request: Request):
+            body = await request.body()
+            sig = request.headers.get("X-Chalkboard-Signature", "")
+            if not verify_webhook_signature(SIGNING_SECRET, body, sig):
+                raise HTTPException(401, "bad signature")
+            payload = json.loads(body)
+            ...
+    """
+    parts = dict(p.split("=", 1) for p in signature_header.split(",") if "=" in p)
+    if "t" not in parts or "v1" not in parts:
+        return False
+    try:
+        t = int(parts["t"])
+    except ValueError:
+        return False
+    if abs(time.time() - t) > tolerance_seconds:
+        return False
+    expected = hmac.new(
+        secret.encode("utf-8"),
+        f"{t}.{payload_bytes.decode('utf-8', errors='replace')}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(expected, parts["v1"])

--- a/sdk/python/examples/quickstart.py
+++ b/sdk/python/examples/quickstart.py
@@ -1,0 +1,48 @@
+"""End-to-end quickstart: create → poll → download.
+
+Usage:
+    export CHALKBOARD_API_KEY=chk_live_...
+    python quickstart.py "How hash tables work"
+"""
+import os
+import sys
+from pathlib import Path
+
+from chalkboard import ChalkboardClient, ChalkboardError
+
+
+def main():
+    if "CHALKBOARD_API_KEY" not in os.environ:
+        print("Set CHALKBOARD_API_KEY first.", file=sys.stderr)
+        sys.exit(1)
+
+    topic = " ".join(sys.argv[1:]) or "Explain B-trees in 90 seconds"
+
+    with ChalkboardClient(api_key=os.environ["CHALKBOARD_API_KEY"]) as client:
+        print(f"Submitting: {topic!r}")
+        try:
+            job = client.create_job(
+                topic=topic,
+                effort="medium",
+                theme="chalkboard",
+                idempotency_key=client.fresh_idempotency_key(),
+            )
+        except ChalkboardError as e:
+            print(f"Create failed: {e.status} {e.detail}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Job {job.id} dispatched (mode={job.mode}). Waiting…")
+        final = client.wait_for_completion(job.id, timeout=900)
+        print(f"Final status: {final.status}")
+
+        if final.status != "completed":
+            print(f"Run did not complete: {final.error}", file=sys.stderr)
+            sys.exit(2)
+
+        out = Path(f"chalkboard-{final.id}.mp4")
+        client.download_file(final.id, "final.mp4", out_path=out)
+        print(f"Wrote {out} ({out.stat().st_size:,} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/examples/verify_webhook.py
+++ b/sdk/python/examples/verify_webhook.py
@@ -1,0 +1,36 @@
+"""Minimal FastAPI webhook receiver.
+
+    pip install chalkboard-sdk fastapi uvicorn
+    export CHALKBOARD_SIGNING_SECRET=<from /account → Webhooks>
+    uvicorn verify_webhook:app --port 8000
+
+Then point a Chalkboard webhook at https://your-host/chalkboard.
+"""
+import json
+import os
+
+from fastapi import FastAPI, HTTPException, Request
+
+from chalkboard import verify_webhook_signature
+
+SIGNING_SECRET = os.environ["CHALKBOARD_SIGNING_SECRET"]
+
+app = FastAPI()
+
+
+@app.post("/chalkboard")
+async def receive(request: Request):
+    body = await request.body()    # raw bytes — DO NOT JSON-decode before verifying
+    sig = request.headers.get("X-Chalkboard-Signature", "")
+    if not verify_webhook_signature(SIGNING_SECRET, body, sig):
+        raise HTTPException(status_code=401, detail="bad signature")
+
+    event = json.loads(body)
+    # event has shape: {id, event, created_at, data: { ...JobResponse... }}
+    print(f"Received {event['event']} for run {event['data']['id']}")
+    if event["event"] == "job.completed":
+        # ... do the thing your integration cares about ...
+        pass
+
+    # Always 2xx so we don't trigger the retry path.
+    return {"received": True}

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "chalkboard-sdk"
+version = "0.1.1"
+description = "Python client for the Chalkboard API — generate narrated explainer videos from your code."
+readme = "README.md"
+license = { text = "MIT" }
+authors = [{ name = "Chalkboard", email = "hello@chalkboard.studio" }]
+requires-python = ">=3.10"
+dependencies = [
+    "httpx>=0.27,<1.0",
+]
+keywords = ["chalkboard", "video-generation", "manim", "claude", "api"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Multimedia :: Video",
+]
+
+[project.urls]
+Homepage = "https://chalkboard.studio"
+Documentation = "https://chalkboard.studio/docs/api"
+Repository = "https://github.com/nicglazkov/Chalkboard"
+Changelog = "https://chalkboard.studio/changelog"
+
+[tool.setuptools.packages.find]
+include = ["chalkboard*"]
+exclude = ["tests*", "examples*"]


### PR DESCRIPTION
## Summary
Mirror of the SDK from the private \`chalkboard-cloud\` repo so it can be distributed publicly via GitHub Releases. The cloud-repo Release URL is auth-gated (private repo) and breaks for users; this repo's Releases are public.

The SDK's content is unchanged from \`chalkboard-cloud\` at commit \`a0c34b3\` (PR #173 in that repo). Single runtime dep: \`httpx\`.

## What lands
- \`sdk/python/chalkboard/\` — typed sync client + exception hierarchy + dataclass models + webhook signature verifier
- \`sdk/python/examples/\` — create+poll+download quickstart + FastAPI webhook-receiver example
- \`sdk/python/pyproject.toml\` — PEP 621 build config; setuptools backend
- \`sdk/python/README.md\` — quickstart + auth + idempotency + webhook-verifier snippets
- README.md gains a "Python SDK" section near the bottom pointing users at \`sdk/python/\` and the install URL on this repo's GH Releases

## Use case
- **Hosted Chalkboard** (chalkboard.studio): default \`base_url=\`, requires a \`chk_live_\` / \`chk_test_\` API key from \`/account\`
- **Self-hosted Chalkboard** (this repo): pass \`base_url="http://localhost:8000/api/v1"\`; typically no key needed

## After merge
1. Tag this commit as \`sdk-py/v0.1.1\` here (\`git tag sdk-py/v0.1.1 && git push --tags\`)
2. \`python -m build\` from \`sdk/python/\` produces wheel + sdist
3. \`gh release create sdk-py/v0.1.1 --notes ...\` with both artifacts attached
4. Delete the broken release on \`chalkboard-cloud\` (\`gh release delete sdk-py/v0.1.1 -R nicglazkov/chalkboard-cloud --yes\`)
5. Update SDK README + audit doc on \`chalkboard-cloud\` to point at this repo's release URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)